### PR TITLE
CCT-5 add blog

### DIFF
--- a/_drafts/2020-04-03-geosensorweb-blog-added.md
+++ b/_drafts/2020-04-03-geosensorweb-blog-added.md
@@ -1,0 +1,34 @@
+---
+layout: post
+title:  "GeoSensorWeb Lab Blog"
+date:   2020-04-03 10:09:57 -0600
+published: true
+category: geosensorweblab
+---
+
+The GeoSensorWeb Lab will from time to time post blog entries.
+
+## Publish
+
+In order for a blog post to be displayed on the site:
+
+* The files should be in the `_posts` folder
+* The file names must have the format: `YYYY-MM-DD-dagger-case-title.md`
+* YYYY-MM-DD in the file name and date field must be earlier than today's date
+   * you can post-date posts this way
+* The `published` field in the front matter must be `published: true`
+   * you can delay or prevent publishing by making it false until ready
+* The extension of the file should correspond to the format
+  * markdown: `md` or `markdown`
+
+## Drafts
+
+Editing posts in the `_drafts` folder allows testing of the post before publication.
+
+### Preview
+
+* Change `published: false` front matter entry to `published: true`
+* Change the date in the name and the date field to yesterday's date
+* Start Jekyll locally with: `bundle exec jekyll serve --drafts`
+* View the site at `http://localhost:4000`
+

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -11,18 +11,13 @@ layout: default
   {{ content }}
 
   <ul class="post-list">
-    {% for post in site.posts %}
-      <li>
-        {% assign date_format = site.minima.date_format | default: "%b %-d, %Y" %}
-        <span class="post-meta">{{ post.date | date: date_format }}</span>
-
-        <h2>
-          <a class="post-link" href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
-        </h2>
-      </li>
-    {% endfor %}
+    {% assign post = site.posts.last %}
+    <li>
+      {% assign date_format = site.minima.date_format | default: "%b %-d, %Y" %}
+      <h2>
+        <a class="post-link" href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
+      </h2>
+    </li>
   </ul>
-
-  <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | relative_url }}">via RSS</a></p>
 
 </div>

--- a/_posts/2017-08-08-meet-the-geosensorweb-lab.markdown
+++ b/_posts/2017-08-08-meet-the-geosensorweb-lab.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "Meet the GeoSensorWeb Lab"
 date:   2017-08-08 16:07:57 -0600
-categories: geosensorweblab
+category: geosensorweblab
 ---
 
 The GeoSensorWeb Lab is a research group at the University of Calgary, Canada that is focused on developing web-enabled geospatial information systems and building interoperability into the Internet of Things.

--- a/blog.md
+++ b/blog.md
@@ -1,0 +1,35 @@
+---
+layout: page
+title: Blog
+permalink: /blog/
+---
+
+  <ul class="post-list">
+    {% for post in site.posts %}
+      <li>
+        {% assign date_format = site.minima.date_format | default: "%b %-d, %Y" %}
+        <span class="post-meta">{{ post.date | date: date_format }}</span>
+
+        <h2>
+          <a class="post-link" href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
+        </h2>
+      </li>
+    {% endfor %}
+  </ul>
+
+  <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | relative_url }}">via RSS</a></p>
+
+<!-- Once meaningful categories are added, use this to display them:
+
+## Categories
+
+{% for category in site.categories %}
+  <h3>{{ category[0] }}</h3>
+  <ul>
+    {% for post in category[1] %}
+      <li><a href="{{ post.url }}">{{ post.title }}</a></li>
+    {% endfor %}
+  </ul>
+{% endfor %}
+
+ -->


### PR DESCRIPTION
## Summary

* add a blog entry to top level menu
* rearrange home page to reference only the welcome message
* add a `_drafts` post for developers describing how to post

## Screenshots

### New Blog Menu Item

![Screen Shot 2020-04-16 at 12 51 49 PM](https://user-images.githubusercontent.com/50335447/79495084-4d54e580-7fe1-11ea-90cf-32889653dc77.png)

### New Blog Page

![Screen Shot 2020-04-16 at 12 52 37 PM](https://user-images.githubusercontent.com/50335447/79495104-53e35d00-7fe1-11ea-8ef7-d1ab80d1ce4a.png)

### Home Page Look

![Screen Shot 2020-04-16 at 12 53 00 PM](https://user-images.githubusercontent.com/50335447/79495118-580f7a80-7fe1-11ea-9313-d2332c57f57a.png)

### Blog Publish Post for Developers

![Screen Shot 2020-04-16 at 12 54 32 PM](https://user-images.githubusercontent.com/50335447/79495184-74131c00-7fe1-11ea-8f4a-291129a89864.png)
